### PR TITLE
Add some scripts to check deployed certificates.

### DIFF
--- a/check-deployment/check-all-services.sh
+++ b/check-deployment/check-all-services.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/awk -f
+
+BEGIN {
+    #dryrun=1
+}
+
+/^#.*/     { next }
+(NF == 2)  {
+    service_name = $1
+    service_port = $2
+    cmd="./check-service.sh '" service_name "' " service_port
+    run(cmd)
+}
+
+END   {}
+
+function run ( command ) {
+    if (dryrun) {
+         print("      - would run: " command);
+    } else {
+        while (command |& getline output) print output
+    }
+}

--- a/check-deployment/check-service.sh
+++ b/check-deployment/check-service.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+command -v openssl >/dev/null 2>&1 || { echo >&2 "openssl is require but it's not installed, aborting."; exit 1; }
+
+service_name=$1
+service_port=$2
+format=$3
+
+if [ -z "$service_name" ] || [ -z "$service_port" ]
+then
+  echo "Usage: check-servcice.sh host port"
+  exit 1
+fi
+
+[ -z "$format" ] && format="h"
+
+echo -n | \
+openssl s_client -servername ${service_name} -connect ${service_name}:${service_port} 2>/dev/null | \
+openssl x509 -noout -dates -fingerprint -subject -nameopt nofname | \
+cut -d '=' -f 2 | \
+{
+  read from;
+  read to;
+  read sha1;
+  read subject;
+  subject="${subject##*,}"
+  from_seconds=`date --date="$from" "+%s"`
+  to_seconds=`date --date="$to" "+%s"`
+  now_seconds=`date "+%s"`
+  if [ "$format" = "h" ]
+  then
+      seconds="$(($to_seconds - $now_seconds))"
+      [ $seconds -gt 0 ] && status="valid" || status="invalid"
+      [ "${service_name}" != "$subject" ] && extra_status=" but subject ${subject} does not match name ${service_name}"
+      echo "${service_name}:${service_port} is $status for $(($seconds/86400)) days${extra_status}"
+  else
+      echo tls_verify,host=${service_name},port=${service_port} seconds_from_valid=$(($now_seconds - $from_seconds)),seconds_to_expire=$(($to_seconds - $now_seconds)),sha1=\"$sha1\"
+  fi
+}

--- a/check-deployment/services.tab
+++ b/check-deployment/services.tab
@@ -1,0 +1,52 @@
+apifocal.com			443
+archiva.apifocal.org		443
+blog.apifocal.com		443
+cdn.apifocal.org		443
+dev.silkmq.org			443
+dg01.silkmq.org			61917
+#dg02.silkmq.org		61917
+docker.apifocal.org		443
+docker-tmp.apifocal.org		443
+#docs.apifocal.com		443
+docs.silkmq.com			443
+ds1.apifocal.org		636
+es2.dev.silkmq.org		443
+es2.stage.silkmq.org		443
+g01.silkmq.com			61617
+g02.silkmq.com			61617
+g03.silkmq.com			61617
+#g04.silkmq.com			61617
+#g05.silkmq.com			61617
+#g06.silkmq.com			61617
+#g07.silkmq.com			61617
+#g08.silkmq.com			61617
+git.apifocal.org		443
+#h03.apifocal.org
+#h04.apifocal.org
+#h07.apifocal.org
+#h08.apifocal.org
+#h10.apifocal.org
+jenkins.apifocal.org		443
+kibana.dev.silkmq.org		443
+kibana.stage.silkmq.org		443
+kopf.es2.dev.silkmq.org		443
+kopf.es2.stage.silkmq.org	443
+ldap.stage.silkmq.org		636
+logs.apifocal.org		443
+#miami.silkmq.com
+monitor.apifocal.org		443
+mqs.dev.silkmq.org		61919
+mqs.silkmq.com			61619
+mqs.stage.silkmq.org		61619
+rancher.apifocal.org		443
+rancher.internal.apifocal.org	443
+rancher.stage.apifocal.org	443
+redmine.apifocal.org		443
+sg01.silkmq.org			61617
+sg02.silkmq.org			61617
+#sg03.silkmq.org		61617
+silkmq.com			443
+stage.apifocal.com		443
+stage.silkmq.org		443
+www.silkmq.com			443
+www.silkmq.org			443


### PR DESCRIPTION
The same scripts can also be used to monitor services at TLS level.

These scripts can produce the data displayed in [this dashboard](https://monitor.apifocal.org/dashboard/db/tls-status?orgId=1) when called by telegraf (this still needs to be setup).

