### PR TITLE
Improve the check service TLS deployment scripts.

### DIFF
--- a/check-deployment/check-all-services.sh
+++ b/check-deployment/check-all-services.sh
@@ -16,7 +16,7 @@ END   {}
 
 function run ( command ) {
     if (dryrun) {
-         print("      - would run: " command);
+	print("      - would run: " command);
     } else {
         while (command |& getline output) print output
     }

--- a/check-deployment/check-service.sh
+++ b/check-deployment/check-service.sh
@@ -8,32 +8,58 @@ format=$3
 
 if [ -z "$service_name" ] || [ -z "$service_port" ]
 then
-  echo "Usage: check-servcice.sh host port"
-  exit 1
+    echo "Usage: check-servcice.sh host port"
+    exit 1
 fi
 
 [ -z "$format" ] && format="h"
 
 echo -n | \
-openssl s_client -servername ${service_name} -connect ${service_name}:${service_port} 2>/dev/null | \
-openssl x509 -noout -dates -fingerprint -subject -nameopt nofname | \
-cut -d '=' -f 2 | \
-{
-  read from;
-  read to;
-  read sha1;
-  read subject;
-  subject="${subject##*,}"
-  from_seconds=`date --date="$from" "+%s"`
-  to_seconds=`date --date="$to" "+%s"`
-  now_seconds=`date "+%s"`
-  if [ "$format" = "h" ]
-  then
-      seconds="$(($to_seconds - $now_seconds))"
-      [ $seconds -gt 0 ] && status="valid" || status="invalid"
-      [ "${service_name}" != "$subject" ] && extra_status=" but subject ${subject} does not match name ${service_name}"
-      echo "${service_name}:${service_port} is $status for $(($seconds/86400)) days${extra_status}"
-  else
-      echo tls_verify,host=${service_name},port=${service_port} seconds_from_valid=$(($now_seconds - $from_seconds)),seconds_to_expire=$(($to_seconds - $now_seconds)),sha1=\"$sha1\"
-  fi
-}
+    openssl s_client -servername ${service_name} -connect ${service_name}:${service_port} 2>/dev/null | \
+    openssl x509 -noout -text -certopt no_header,no_version,no_serial,no_signame,no_issuer,no_pubkey,no_sigdump,no_aux 2>/dev/null | \
+    {
+	while read line
+	do
+	    case $line in
+		Not\ Before* )
+		    from="${line#*:}"
+		    ;;
+		Not\ After* )
+		    to="${line#*:}"
+		    ;;
+		Subject* )
+		    subject="${line#*CN=}"
+		    ;;
+		X509v3\ Subject\ Alternative\ Name* )
+		    read alternative_names
+		    alternative_names=$(echo ${alternative_names} | tr ", DNS:" " " | tr -s " ")
+		    ;;
+	    esac
+	done
+	status=0
+	# service is probably down
+	[ -z "$from" ] || [ -z "$to" ] || [ -z "$subject" ] && { status=1; status_message="invalid, failed to connect/obtain certificate information"; }
+	from_seconds=`date --date="$from" "+%s"`
+	to_seconds=`date --date="$to" "+%s"`
+	now_seconds=`date "+%s"`
+	seconds="$(($to_seconds - $now_seconds))"
+	if [ $status -eq 0 ]
+	then
+	    [ $seconds -le 0 ] && { status=2; status_message="invalid, certificate expired $((-$seconds/86400)) days ago"; }
+	    name_match=0
+	    for alternative_name in $alternative_names
+	    do
+		# note that this does not support wildcard matching 
+		[ "${service_name}" = "${alternative_name}" ] && name_match=1 && break
+	    done
+	    [ $name_match -eq 0 ] && { status=3; status_message="invalid, name ${service_name} does not match alternative names${alternative_names}"; }
+	fi
+	if [ "$format" = "h" ]
+	then
+	    [ $status -eq 0 ] && status_message="valid, for $(($seconds/86400)) days"
+	    echo "${service_name}:${service_port} is ${status_message}"
+	else
+	    # status mapping: 0 - service OK, 1 - service down, 2 - service up but expired certificate, 3 - service up,certificate valid, but name does not match alternative names
+	    echo tls_verify,host=${service_name},port=${service_port} seconds_from_valid=$(($now_seconds - $from_seconds)),seconds_to_expire=$(($to_seconds - $now_seconds)),status=$status
+	fi
+    }

--- a/check-deployment/services.tab
+++ b/check-deployment/services.tab
@@ -1,52 +1,90 @@
-apifocal.com			443
+# internal services
+
+ds1.apifocal.org		636
+
+# ranchers
+rancher.apifocal.org		443
+rancher.internal.apifocal.org	443
+rancher.stage.apifocal.org	443
+
+# dev(ops) services
 archiva.apifocal.org		443
-blog.apifocal.com		443
-cdn.apifocal.org		443
-dev.silkmq.org			443
-dg01.silkmq.org			61917
-#dg02.silkmq.org		61917
 docker.apifocal.org		443
 docker-tmp.apifocal.org		443
+git.apifocal.org		443
+jenkins.apifocal.org		443
+logs.apifocal.org		443
+monitor.apifocal.org		443
+redmine.apifocal.org		443
+
+# points to cipi's host, expired cetificate
+cdn.apifocal.org		443
+# no dns entry, cleanup certificate
+#miami.silkmq.com		443
+
+# site
+apifocal.com			443
+stage.apifocal.com		443
+blog.apifocal.com		443
+# currently a http redirect too google drive, fix https
 #docs.apifocal.com		443
-docs.silkmq.com			443
-ds1.apifocal.org		636
+
+# github site, fix https
+www.silkmq.org			443
+
+# SILKMQ
+
+# dev frontends
+dev.silkmq.org			443
+kibana.dev.silkmq.org		443
+kopf.es2.dev.silkmq.org		443
 es2.dev.silkmq.org		443
+
+# stage frontends
+stage.silkmq.org		443
+kibana.stage.silkmq.org		443
+kopf.es2.stage.silkmq.org	443
 es2.stage.silkmq.org		443
+
+# stage ldap
+ldap.stage.silkmq.org		636
+
+# prod frontends
+silkmq.com			443
+www.silkmq.com			443
+docs.silkmq.com			443
+
+# discovery brokers
+mqs.dev.silkmq.org		61919
+mqs.silkmq.com			61619
+mqs.stage.silkmq.org		61619
+
+# dev gateway brokers
+dg01.silkmq.org			61917
+# pints to hadrian.us, fix dns
+dg02.silkmq.org			61917
+h03.apifocal.org		61917
+h04.apifocal.org		61917
+
+# stage gateway brokers
+sg01.silkmq.org			61617
+# both sg01 and sg02 points to h03, fix DNS
+sg02.silkmq.org			61617
+# points to h04 but no staging gateway config on h04
+sg03.silkmq.org			61617
+h03.apifocal.org		61617
+h04.apifocal.org		61617
+
+# prod gateway brokers
 g01.silkmq.com			61617
 g02.silkmq.com			61617
 g03.silkmq.com			61617
+# no dns entry, cleanup certificate
 #g04.silkmq.com			61617
 #g05.silkmq.com			61617
 #g06.silkmq.com			61617
 #g07.silkmq.com			61617
 #g08.silkmq.com			61617
-git.apifocal.org		443
-#h03.apifocal.org
-#h04.apifocal.org
-#h07.apifocal.org
-#h08.apifocal.org
-#h10.apifocal.org
-jenkins.apifocal.org		443
-kibana.dev.silkmq.org		443
-kibana.stage.silkmq.org		443
-kopf.es2.dev.silkmq.org		443
-kopf.es2.stage.silkmq.org	443
-ldap.stage.silkmq.org		636
-logs.apifocal.org		443
-#miami.silkmq.com
-monitor.apifocal.org		443
-mqs.dev.silkmq.org		61919
-mqs.silkmq.com			61619
-mqs.stage.silkmq.org		61619
-rancher.apifocal.org		443
-rancher.internal.apifocal.org	443
-rancher.stage.apifocal.org	443
-redmine.apifocal.org		443
-sg01.silkmq.org			61617
-sg02.silkmq.org			61617
-#sg03.silkmq.org		61617
-silkmq.com			443
-stage.apifocal.com		443
-stage.silkmq.org		443
-www.silkmq.com			443
-www.silkmq.org			443
+h07.apifocal.org		61617
+h08.apifocal.org		61617
+h10.apifocal.org		61617


### PR DESCRIPTION
1. Reorganize and comment services definiton file.
2. Improve name matching in the TLS check script (wildcards not supported)
3. Better status messages
4. Save the status when influxdb output format is selected
5. Proper whitespace usage