### PR TITLE
Increase sleep duration of godaddy authenticator

### DIFF
--- a/godaddy/authenticator.sh
+++ b/godaddy/authenticator.sh
@@ -37,4 +37,4 @@ curl -s -X PUT "https://api.godaddy.com/v1/domains/${DOMAIN}/records/TXT/$RECORD
 
 
 # Sleep to make sure the change has time to propagate over to DNS
-sleep 1
+sleep 60


### PR DESCRIPTION
Increase duration to 60s after getting banned for 1 hour by letsencrypt
because godaddy was unable to operate the DNS changes fast enough (even
though it used to, hence the initial 1 second sleep)